### PR TITLE
Rewrite code for this demo to match its intended purpose

### DIFF
--- a/demos/service-workflow/src/main/java/greetingworkflow/GreetingActivities.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/GreetingActivities.java
@@ -7,6 +7,4 @@ public interface GreetingActivities {
 
     String greetInSpanish(String name);
 
-    String farewellInSpanish(String name);
-    
 }

--- a/demos/service-workflow/src/main/java/greetingworkflow/GreetingActivitiesImpl.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/GreetingActivitiesImpl.java
@@ -11,22 +11,13 @@ public class GreetingActivitiesImpl implements GreetingActivities {
 
     @Override
     public String greetInSpanish(String name) {
-        return callService("get-spanish-greeting", name);
-    }
-
-    @Override
-    public String farewellInSpanish(String name) {
-        return callService("get-spanish-farewell", name);
-    }
-
-    String callService(String stem, String name) {
         StringBuilder builder = new StringBuilder();
 
-        String baseUrl = "http://localhost:9999/%s?name=%s";
+        String baseUrl = "http://localhost:9999/get-spanish-greeting?name=%s";
 
         URL url = null;
         try {
-            url = new URL(String.format(baseUrl, stem, URLEncoder.encode(name, "UTF-8")));
+            url = new URL(String.format(baseUrl, URLEncoder.encode(name, "UTF-8")));
         } catch (IOException e) {
             throw Activity.wrap(e);
         }

--- a/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorker.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorker.java
@@ -6,6 +6,7 @@ import io.temporal.worker.Worker;
 import io.temporal.worker.WorkerFactory;
 
 public class GreetingWorker {
+
     public static void main(String[] args) {
 
         WorkflowServiceStubs service = WorkflowServiceStubs.newLocalServiceStubs();

--- a/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorkflow.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorkflow.java
@@ -8,5 +8,5 @@ public interface GreetingWorkflow {
 
     @WorkflowMethod
     String greetSomeone(String name);
-    
+
 }

--- a/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorkflowImpl.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/GreetingWorkflowImpl.java
@@ -8,16 +8,14 @@ import java.time.Duration;
 public class GreetingWorkflowImpl implements GreetingWorkflow {
 
     ActivityOptions options = ActivityOptions.newBuilder()
-        .setStartToCloseTimeout(Duration.ofSeconds(5))
-        .build();
+            .setStartToCloseTimeout(Duration.ofSeconds(5))
+            .build();
 
-    private final GreetingActivities activities = Workflow.newActivityStub(GreetingActivities.class, options);
+    private final GreetingActivities activities
+            = Workflow.newActivityStub(GreetingActivities.class, options);
 
     @Override
-    public String greetSomeone(String name){
-        String spanishGreeting = activities.greetInSpanish(name);
-        String spanishFarewell = activities.farewellInSpanish(name);
-
-        return "\n" + spanishGreeting + "\n" + spanishFarewell;
+    public String greetSomeone(String name) {
+        return activities.greetInSpanish(name);
     }
 }

--- a/demos/service-workflow/src/main/java/greetingworkflow/Microservice.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/Microservice.java
@@ -26,10 +26,9 @@ public class Microservice {
 
         // Define the service endpoints and handlers
         On.get("/get-spanish-greeting").plain(new GreetingHandler());
-        On.get("/get-spanish-farewell").plain(new FarewellHandler());
 
         // Also define a catch-all to return an HTTP 404 Not Found error if the URL
-        // path in the request didn't match an endpoint defined above. It's essential
+        // path in the request didn't match the endpoint defined above. It's essential
         // that this code remains at the end.
         On.req((req, resp) -> {
             String message = String.format("Error: Invalid endpoint address '%s'", req.path());
@@ -50,24 +49,6 @@ public class Microservice {
 
             String name = params.get("name");
             String response = String.format("¡Hola, %s!", name);
-            return U.str(response);
-        }
-
-    }
-
-    private static class FarewellHandler implements ReqRespHandler {
-
-        @Override
-        public Object execute(Req req, Resp resp) throws Exception {
-            Map<String, String> params = req.params();
-
-            if (!params.containsKey("name")) {
-                String message = "Error: Missing required 'name' parameter!";
-                return req.response().result(message).code(500);
-            }
-
-            String name = params.get("name");
-            String response = String.format("¡Adiós, %s!", name);
             return U.str(response);
         }
 

--- a/demos/service-workflow/src/main/java/greetingworkflow/Starter.java
+++ b/demos/service-workflow/src/main/java/greetingworkflow/Starter.java
@@ -6,17 +6,18 @@ import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 
 public class Starter {
+
     public static void main(String[] args) throws Exception {
 
         WorkflowServiceStubs service = WorkflowServiceStubs.newLocalServiceStubs();
 
-        WorkflowClient client = WorkflowClient.newInstance(service);        
+        WorkflowClient client = WorkflowClient.newInstance(service);
 
         WorkflowOptions options = WorkflowOptions.newBuilder()
-                    .setWorkflowId("greeting-workflow")
-                    .setTaskQueue("greeting-tasks")
-                    .build();
-       
+                .setWorkflowId("greeting-workflow")
+                .setTaskQueue("greeting-tasks")
+                .build();
+
         GreetingWorkflow workflow = client.newWorkflowStub(GreetingWorkflow.class, options);
 
         String greeting = workflow.greetSomeone(args[0]);


### PR DESCRIPTION
## What was changed
This demo is intended for live deliveries, during which we provide a smooth transition between the Workflow-only hello-workflow exercise and the subsequent Workflow-and-two-Activities farewell-workflow exercise. We do this by showing a Workflow that calls a single Activity (which introduces the microservice) and that Activity uses inline code instead of a utility method in order to make what it's doing more clear. 

## Why?
The code in this demo currently seems to be basically a copy of the code from the farewell-workflow exercise, which is unnecessary duplication and does not serve the intended purpose stated above. My PR provides a Java equivalent to the corresponding demo from the _Temporal 101 with Go_ course.

## Checklist
How was this tested:

I compiled and ran the code locally.